### PR TITLE
Do not rely Tokenizer.h to transitively include <set>

### DIFF
--- a/src/fuzzy_match.cc
+++ b/src/fuzzy_match.cc
@@ -3,6 +3,7 @@
 #include <queue>
 #include <vector>
 #include <cmath>
+#include <set>
 
 #include <fuzzy/ngram_matches.hh>
 #include <fuzzy/edit_distance.hh>


### PR DESCRIPTION
Newer versions of Tokenizer.h no longer include `<set>`.