### PR TITLE
Do not look for Tokenizer install when it is another CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,13 @@ set(CMAKE_CXX_STANDARD 11)
 
 add_compile_options(-pedantic -ansi)
 
-find_library(OPENNMT_TOKENIZER_LIB OpenNMTTokenizer REQUIRED HINTS ${OPENNMT_TOKENIZER_ROOT}/lib)
-find_path(OPENNMT_TOKENIZER_INCLUDE onmt/Tokenizer.h REQUIRED HINTS ${OPENNMT_TOKENIZER_ROOT}/include)
+if(TARGET OpenNMTTokenizer)
+  set(OPENNMT_TOKENIZER_LIB OpenNMTTokenizer)
+  set(OPENNMT_TOKENIZER_INCLUDE "")  # Resolved via the target.
+else()
+  find_library(OPENNMT_TOKENIZER_LIB OpenNMTTokenizer REQUIRED HINTS ${OPENNMT_TOKENIZER_ROOT}/lib)
+  find_path(OPENNMT_TOKENIZER_INCLUDE onmt/Tokenizer.h REQUIRED HINTS ${OPENNMT_TOKENIZER_ROOT}/include)
+endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 


### PR DESCRIPTION
This can be needed when Fuzzy and Tokenizer are both submodules of the same project.