### PR TITLE
Remove backlog processing

### DIFF
--- a/include/fuzzy/ngram_matches.hh
+++ b/include/fuzzy/ngram_matches.hh
@@ -22,7 +22,7 @@ namespace fuzzy
                  float fuzzy, unsigned p_length,
                  const SuffixArray&);
 
-    void register_ranges(bool create, Range);
+    void register_ranges(Range);
     /* same function with lazy injection feature - if match_length
        smaller than min_seq_len, we will not process the entries for the moment */
     void register_ranges(Range, unsigned min_seq_len);
@@ -39,6 +39,5 @@ namespace fuzzy
     unsigned _p_length;
     const SuffixArray& _suffixArray;
     tsl::hopscotch_map<unsigned, AgendaItem> _psentences; // association of sentence id => AgendaItem, owns the AgendaItem
-    std::vector<Range> _ranges_toprocess;
   };
 }

--- a/src/fuzzy_match.cc
+++ b/src/fuzzy_match.cc
@@ -472,7 +472,7 @@ namespace fuzzy
         std::pair<size_t, size_t> range_suffixid = _suffixArrayIndex->get_SuffixArray().equal_range(p_i, 0, 0);
 
         if (range_suffixid.first != range_suffixid.second)
-          nGramMatches.register_ranges(true, fuzzy::Range({range_suffixid.first, range_suffixid.second, 1}));
+          nGramMatches.register_ranges(fuzzy::Range({range_suffixid.first, range_suffixid.second, 1}));
       }
     }
 
@@ -535,7 +535,6 @@ namespace fuzzy
       if (p_i.size() >= 2)
         nGramMatches.register_ranges(fuzzy::Range({previous_range_suffixid.first, previous_range_suffixid.second, p_i.size()}), min_subseq_length);
     }
-    nGramMatches.process_backlogs();
 
     /* Consolidation of the results */
 

--- a/src/ngram_matches.cc
+++ b/src/ngram_matches.cc
@@ -51,7 +51,7 @@ namespace fuzzy
   }
 
   void
-  NGramMatches::register_ranges(bool create, Range range)
+  NGramMatches::register_ranges(Range range)
   {
     // For each suffix that matches at least r.match_length
     for (auto i = range.suffix_first; i < range.suffix_last; i++)
@@ -65,12 +65,11 @@ namespace fuzzy
       const auto sentence_id = _suffixArray.suffixid2sentenceid()[i].sentence_id;
       auto* agendaItem = get_agendaitem(sentence_id);
       if (!agendaItem)
-      {
-        if (!create)
-          continue;
-        else
-          agendaItem = new_agendaitem(sentence_id, _p_length);
-      }
+        agendaItem = new_agendaitem(sentence_id, _p_length);
+
+      // The match will update the AgendaItem entry only if its length is the longest to date.
+      if (range.match_length <= agendaItem->maxmatch)
+        continue;
 
       // Update the AgendaItem with the match
       for(size_t j=0; j < range.match_length; j++)
@@ -86,20 +85,7 @@ namespace fuzzy
 
   void
   NGramMatches::register_ranges(Range r, unsigned min_seq_len) {
-    if (r.match_length < min_exact_match)
-      return;
-
-    if (r.match_length >= min_seq_len)
-      register_ranges(true, r);
-    else
-      _ranges_toprocess.emplace_back(std::move(r));
-  }
-
-  void
-  NGramMatches::process_backlogs() {
-    for(auto &r: _ranges_toprocess)
-    {
-      register_ranges(false, r);
-    }
+    if (r.match_length >= min_exact_match && r.match_length >= min_seq_len)
+      register_ranges(r);
   }
 }


### PR DESCRIPTION
From my understanding, the backlog of `Range` does not have any impact in the match.

In the previous code, the method `register_ranges(bool create, Range range)` mutated the collection of `AgendaItem` if one of the following conditions are met:

1. A `sentence_id` is seen for the first time and `create` is true
2. The match length is the longest to date for the retrieved `AgendaItem`

However, these 2 conditions are not met for ranges that are stored in the backlog:

1. `create` is false
2. The match length can not be the longest by construction (the backlog was filled with ranges where `r.match_length < min_seq_len`)

So I think we can remove this backlog. In my test with a 5M index the output is the same and performance is improved by 10x.

@ClementChouteau Can you check that? Maybe I missed something.