### PR TITLE
Small optimizations and cleanup in edit distance functions

### DIFF
--- a/include/fuzzy/edit_distance.hh
+++ b/include/fuzzy/edit_distance.hh
@@ -5,8 +5,6 @@
 
 namespace fuzzy
 {
-  int   _edit_distance_char_nonempty(const char *s1, int n1, const char *s2, int n2);
-
   int   _edit_distance_char(const char *s1, int n1, const char *s2, int n2);
 
   float _edit_distance(const unsigned* thes, const Sentence &reals, int slen,

--- a/include/fuzzy/edit_distance.hxx
+++ b/include/fuzzy/edit_distance.hxx
@@ -4,7 +4,12 @@
 
 namespace fuzzy
 {
-  inline int _edit_distance_char_nonempty(const char *s1, int n1, const char *s2, int n2) {
+  inline int _edit_distance_char(const char *s1, int n1, const char *s2, int n2) {
+    if (n1 == 0)
+      return n2;
+    if (n2 == 0)
+      return n1;
+
     boost::multi_array<int, 2> arr(boost::extents[n1+1][n2+1]);
 
     arr[0][0] = 0;
@@ -17,19 +22,15 @@ namespace fuzzy
     {
       for (int j = 1; j < n2 + 1; j++)
       {
-        int diff = 0;
-        if (s1[i-1] != s2[j-1])
-          diff = 1;
-        arr[i][j] = std::min(std::min(arr[i - 1][j] + 1,
-                                      arr[i][j - 1] + 1),
-                             arr[i - 1][j - 1] + diff);
+        arr[i][j] = std::min(
+          {
+            arr[i - 1][j] + 1,
+            arr[i][j - 1] + 1,
+            arr[i - 1][j - 1] + (s1[i - 1] == s2[j - 1] ? 0 : 1)
+          });
       }
     }
-    return arr[n1][n2];
-  }
 
-  inline int _edit_distance_char(const char *s1, int n1, const char *s2, int n2) {
-    if (n1==0 || n2==0) return n1+n2;
-    return _edit_distance_char_nonempty(s1, n1, s2, n2);
+    return arr[n1][n2];
   }
 }


### PR DESCRIPTION
* Remove non useful "nonempty" edit distance function (the emptiness check is trivial)
* Remove intermediate `diff` variable in `_edit_distance_char`
* Call the `std::min` overload with `std::initializer_list`
* Avoid 2 matrix lookups `arr[i][j]` in `_edit_distance` main loop