### PR TITLE
Set ios_base::open_mode to binary in import_binarized_fuzzy_matcher

### DIFF
--- a/src/fuzzy_matcher_binarization.cc
+++ b/src/fuzzy_matcher_binarization.cc
@@ -34,7 +34,7 @@ namespace fuzzy
   {
     std::ifstream ifs;
     ifs.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-    ifs.open(binarized_tm_filename.c_str());
+    ifs.open(binarized_tm_filename.c_str(), std::ios_base::binary);
 
     char buffer[4];
     ifs.read(buffer, 4);


### PR DESCRIPTION
The `std::ifstream`'s default open mode is `ios_base::in` so we need to set it to `ios_base::binary`. In macOS with clang, it seems there's no problem as it is, but in Windows with MSVC it crashes at runtime when it tries to load the binarized tm. 