### PR TITLE
Make max_tokens_in_pattern configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 
 Simplest command is the following:
 ```
-FuzzyMatch-cli -c CORPUS [--penalty_tokens (none|tag,sep/jnr,pct)]
+FuzzyMatch-cli -c CORPUS [--penalty-tokens (none|tag,sep/jnr,pct,cas,nbr)] [--max-tokens-in-pattern N]
 ```
 
 * `CORPUS` can be a single file - in which case, the index of each segment is simply the sentence id - or you can provide a target file using `-c CORPUSSOURCE,CORPUSTARGET` and add option `--add-target` to include in the index the actual target sentence (format ID=target). This is useful for having the index fully containing the translation memory. Not useful, if the translation memory is saved in side database.
-* `--penalty_tokens` (default `tag,cas,nbr`) is either `none` or comma-separated list of `tag`, `sep`, `jnr`, `pct`, `nbr`, `cas` modifying normalization (for `cas` performing case normalization, and `nbr` triggering number normalization), removing some tokens from index (`tag` for tags, and `pct` for punctuations), or generates spacer/joiner (`sep`/`jnr`). In each case, a penalty tokens is added.
+* `--penalty-tokens` (default `tag,cas,nbr`) is either `none` or comma-separated list of `tag`, `sep`, `jnr`, `pct`, `nbr`, `cas` modifying normalization (for `cas` performing case normalization, and `nbr` triggering number normalization), removing some tokens from index (`tag` for tags, and `pct` for punctuations), or generates spacer/joiner (`sep`/`jnr`). In each case, a penalty tokens is added.
+* `--max-tokens-in-pattern` (default: 300) limits how long the pattern can be. This is necessary to prevent poor match performance, because the edit distance computation runs in O(T^2) where T is the number of tokens in the pattern.
 
 This option used in index forces the same logic in matching.
 
@@ -35,9 +36,6 @@ Add `--no-perfect` (`-P`) to discard perfect matches. For instance the following
 ```
 FuzzyMatch-cli -l en -i CORPUS.fmi -a match -f 0.7 -N 4 -n 1 -P < INPUTFILE
 ```
-
-*To prevent FuzzyMatch from freezing there is a limit on how long the pattern can be, the limit is 300 tokens now.*
-*This is necessary because the edit distance computation runs in O(T^2) where T is the number of tokens in the pattern.*
 
 # The Algorithm
 ## Tokenization and Vocabulary Indexing

--- a/cli/src/FuzzyMatch-cli.cc
+++ b/cli/src/FuzzyMatch-cli.cc
@@ -195,8 +195,9 @@ class processor {
 public:
   processor(int pt, float fuzzy, int nmatch, bool no_perfect,
             int min_subseq_length, float min_subseq_ratio,
-            float idf_penalty, bool subseq_idf_weighting):
-             _fuzzyMatcher(pt),
+            float idf_penalty, bool subseq_idf_weighting,
+            size_t max_tokens_in_pattern):
+             _fuzzyMatcher(pt, max_tokens_in_pattern),
              _fuzzy(fuzzy),
              _nmatch(nmatch),
              _no_perfect(no_perfect),
@@ -289,6 +290,7 @@ int main(int argc, char** argv)
   int nthreads;
   int min_subseq_length;
   float min_subseq_ratio;
+  size_t max_tokens_in_pattern;
   fuzzyOptions.add_options()
     ("action,a", po::value(&action)->default_value("index"), "Action on the corpus (index|match|subseq"
 #ifndef NDEBUG
@@ -310,6 +312,7 @@ int main(int argc, char** argv)
                                                                         "`sep`/`jnr` and/or `pct`.")
     ("idf-penalty,I", po::value(&idf_penalty)->default_value(0), "if not 0, apply idf-penalty on missing tokens")
     ("subseq-idf-weighting,w", po::bool_switch(), "use idf weighting in finding longest subsequence")
+    ("max-tokens-in-pattern", po::value(&max_tokens_in_pattern)->default_value(fuzzy::SuffixArrayIndex::DEFAULT_MAX_TOKENS_IN_PATTERN), "Patterns containing more tokens than this value are ignored")
     ("nthreads,N", po::value(&nthreads)->default_value(4), "number of thread to use for match")
     ;
 
@@ -380,7 +383,8 @@ int main(int argc, char** argv)
 
   processor O(pt, fuzzy, nmatch, no_perfect,
               min_subseq_length, min_subseq_ratio,
-              idf_penalty, subseq_idf_weighting);
+              idf_penalty, subseq_idf_weighting,
+              max_tokens_in_pattern);
 
   if (index_file.length()) {
     TICK("Loading index_file: "+index_file);

--- a/include/fuzzy/fuzzy_match.hh
+++ b/include/fuzzy/fuzzy_match.hh
@@ -38,7 +38,8 @@ namespace fuzzy
       std::string id;
     };
 
-    FuzzyMatch(int pt=penalty_token::pt_none);
+    FuzzyMatch(int pt = penalty_token::pt_none,
+               size_t max_tokens_in_pattern = SuffixArrayIndex::DEFAULT_MAX_TOKENS_IN_PATTERN);
 
     bool add_tm(const std::string& id, const Tokens& norm, bool sort = true);
     bool add_tm(const std::string& id, const Sentence& source, const Tokens& norm, bool sort = true);
@@ -94,6 +95,9 @@ namespace fuzzy
                                  std::vector<std::string> &tokens,
                                  std::vector<std::vector<std::string>> &features) const;
     std::ostream& dump(std::ostream& os) const;
+
+    size_t max_tokens_in_pattern() const;
+
   private:
     friend class boost::serialization::access;
     friend void import_binarized_fuzzy_matcher(const std::string& binarized_tm_filename, FuzzyMatch& fuzzy_matcher);

--- a/include/fuzzy/fuzzy_match.hxx
+++ b/include/fuzzy/fuzzy_match.hxx
@@ -3,6 +3,11 @@
 
 namespace fuzzy
 {
+  inline size_t FuzzyMatch::max_tokens_in_pattern() const
+  {
+    return _suffixArrayIndex->max_tokens_in_pattern();
+  }
+
   template<class Archive>
   void FuzzyMatch::save(Archive& archive, unsigned int) const
   {

--- a/include/fuzzy/suffix_array_index.hh
+++ b/include/fuzzy/suffix_array_index.hh
@@ -15,7 +15,9 @@ namespace fuzzy
   class SuffixArrayIndex
   {
   public:
-    const static size_t MAX_TOKENS_IN_PATTERN = 300; // if you change this value, update README.md
+    static const size_t DEFAULT_MAX_TOKENS_IN_PATTERN;
+
+    SuffixArrayIndex(size_t max_tokens_in_pattern = DEFAULT_MAX_TOKENS_IN_PATTERN);
 
     const SuffixArray &get_SuffixArray() const;
     VocabIndexer      &get_VocabIndexer();
@@ -32,16 +34,24 @@ namespace fuzzy
     std::string        sentence(size_t s_id) const;
     std::ostream&      dump(std::ostream& os) const;
 
+    size_t max_tokens_in_pattern() const;
+
   private:
     friend class boost::serialization::access;
 
     template<class Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    void save(Archive&, unsigned int version) const;
+
+    template<class Archive>
+    void load(Archive&, unsigned int version);
+
+    BOOST_SERIALIZATION_SPLIT_MEMBER()
 
     VocabIndexer _vocabIndexer;
     SuffixArray  _suffixArray;
     std::vector<std::string> _ids;
     std::vector<Sentence>    _real_tokens;
+    size_t _max_tokens_in_pattern;
   };
 }
 

--- a/include/fuzzy/suffix_array_index.hxx
+++ b/include/fuzzy/suffix_array_index.hxx
@@ -24,14 +24,38 @@ namespace fuzzy
     return _ids.size();
   }
 
+  inline size_t
+  SuffixArrayIndex::max_tokens_in_pattern() const
+  {
+    return _max_tokens_in_pattern;
+  }
+
   template<class Archive>
   void
-  SuffixArrayIndex::serialize(Archive& ar, const unsigned int version)
+  SuffixArrayIndex::save(Archive& ar, unsigned int) const
   {
-    ar &
-    _vocabIndexer &
-    _suffixArray &
-    _ids &
-      _real_tokens;
+    ar
+      & _vocabIndexer
+      & _suffixArray
+      & _ids
+      & _real_tokens
+      & _max_tokens_in_pattern;
   }
+
+  template<class Archive>
+  void
+  SuffixArrayIndex::load(Archive& ar, unsigned int version)
+  {
+    ar
+      & _vocabIndexer
+      & _suffixArray
+      & _ids
+      & _real_tokens;
+
+    if (version > 0)
+      ar & _max_tokens_in_pattern;
+  }
+
 }
+
+BOOST_CLASS_VERSION(fuzzy::SuffixArrayIndex, 1)

--- a/include/fuzzy/suffix_array_index.hxx
+++ b/include/fuzzy/suffix_array_index.hxx
@@ -52,7 +52,7 @@ namespace fuzzy
       & _ids
       & _real_tokens;
 
-    if (version > 0)
+    if (version >= 1)
       ar & _max_tokens_in_pattern;
   }
 

--- a/src/fuzzy_match.cc
+++ b/src/fuzzy_match.cc
@@ -26,9 +26,9 @@ namespace fuzzy
   };
 
 
-  FuzzyMatch::FuzzyMatch(int pt)
+  FuzzyMatch::FuzzyMatch(int pt, size_t max_tokens_in_pattern)
   : _pt(pt)
-  , _suffixArrayIndex(boost::make_unique<SuffixArrayIndex>())
+  , _suffixArrayIndex(boost::make_unique<SuffixArrayIndex>(max_tokens_in_pattern))
   {
     _update_tokenizer();
   }
@@ -429,7 +429,7 @@ namespace fuzzy
     size_t p_length = pattern.size();
 
     // performance guard
-    if (p_length >= SuffixArrayIndex::MAX_TOKENS_IN_PATTERN)
+    if (p_length > max_tokens_in_pattern())
     {
       return false; // no matches
     }

--- a/src/suffix_array_index.cc
+++ b/src/suffix_array_index.cc
@@ -2,13 +2,20 @@
 
 namespace fuzzy
 {
+  const size_t SuffixArrayIndex::DEFAULT_MAX_TOKENS_IN_PATTERN = 300; // if you change this value, update README.md
+
+  SuffixArrayIndex::SuffixArrayIndex(size_t max_tokens_in_pattern)
+    : _max_tokens_in_pattern(max_tokens_in_pattern)
+  {
+  }
+
   int
   SuffixArrayIndex::add_tm(const std::string& id,
                            const Sentence& real_tokens,
                            const Tokens& norm_tokens,
                            bool sort)
   {
-    if (!real_tokens.empty() && norm_tokens.size() < MAX_TOKENS_IN_PATTERN) // patterns greater than this size would be ignored in match
+    if (!real_tokens.empty() && norm_tokens.size() <= _max_tokens_in_pattern) // patterns greater than this size would be ignored in match
     {
       std::vector<unsigned> tokens_idx = _vocabIndexer.getIndexCreate(norm_tokens);
       _suffixArray.add_sentence(tokens_idx);


### PR DESCRIPTION
The value was hardcoded to 300 but in many cases we can configure a smaller value. The value is saved in the index.