### PR TITLE
Simplify register_ranges method

### DIFF
--- a/include/fuzzy/agenda_item.hh
+++ b/include/fuzzy/agenda_item.hh
@@ -18,6 +18,6 @@ namespace fuzzy
     std::vector<bool> map_pattern; /* set of unigrams that are both in the pattern and in the suffix
                                       map_pattern[i]==true means that the word pattern[i] appears in the suffix */
     int coverage; // number of true values in map_pattern
-    int maxmatch; // maximum length of the longest subsequence between the sentence associated with the AgendaItem and the pattern
+    size_t maxmatch; // maximum length of the longest subsequence between the sentence associated with the AgendaItem and the pattern
   };
 }

--- a/include/fuzzy/ngram_matches.hh
+++ b/include/fuzzy/ngram_matches.hh
@@ -5,16 +5,8 @@
 
 #include <fuzzy/tsl/hopscotch_map.h>
 
-#include <vector>
-
 namespace fuzzy
 {
-  struct Range {
-    size_t suffix_first;
-    size_t suffix_last;
-    size_t match_length;
-  };
-
   class NGramMatches
   {
   public:
@@ -23,7 +15,7 @@ namespace fuzzy
                  unsigned min_seq_len,
                  const SuffixArray&);
 
-    void register_ranges(Range);
+    void register_suffix_range(size_t begin, size_t end, size_t match_length);
     int get_sentence_count() const;
     tsl::hopscotch_map<unsigned, AgendaItem>& get_psentences();
 
@@ -31,8 +23,6 @@ namespace fuzzy
     unsigned min_exact_match; // Any suffix without an subsequence of at least this with the pattern won't be accepted later
 
   private:
-    AgendaItem* get_agendaitem(unsigned);
-    AgendaItem* new_agendaitem(unsigned, unsigned);
     unsigned _p_length;
     unsigned _min_seq_len;
     const SuffixArray& _suffixArray;

--- a/src/fuzzy_match.cc
+++ b/src/fuzzy_match.cc
@@ -460,7 +460,7 @@ namespace fuzzy
       std::pair<size_t, size_t> range_suffixid = _suffixArrayIndex->get_SuffixArray().equal_range(pattern_wids.data(), p_length);
 
       if (range_suffixid.first != range_suffixid.second)
-        nGramMatches.register_ranges(fuzzy::Range({range_suffixid.first, range_suffixid.second, p_length}));
+        nGramMatches.register_suffix_range(range_suffixid.first, range_suffixid.second, p_length);
     }
 
     for (size_t it=0; it < p_length; it++)
@@ -499,8 +499,12 @@ namespace fuzzy
           if (subseq_length > 2)
           {
             /* register (n-1) grams */
-            nGramMatches.register_ranges(fuzzy::Range({previous_range_suffixid.first, range_suffixid.first, subseq_length - 1}));
-            nGramMatches.register_ranges(fuzzy::Range({range_suffixid.second, previous_range_suffixid.second, subseq_length - 1}));
+            nGramMatches.register_suffix_range(previous_range_suffixid.first,
+                                               range_suffixid.first,
+                                               subseq_length - 1);
+            nGramMatches.register_suffix_range(range_suffixid.second,
+                                               previous_range_suffixid.second,
+                                               subseq_length - 1);
           }
 
           previous_range_suffixid = std::move(range_suffixid);
@@ -512,7 +516,9 @@ namespace fuzzy
         }
       }
       if (subseq_length >= 2)
-        nGramMatches.register_ranges(fuzzy::Range({previous_range_suffixid.first, previous_range_suffixid.second, subseq_length}));
+        nGramMatches.register_suffix_range(previous_range_suffixid.first,
+                                           previous_range_suffixid.second,
+                                           subseq_length);
     }
 
     /* Consolidation of the results */

--- a/src/ngram_matches.cc
+++ b/src/ngram_matches.cc
@@ -59,16 +59,19 @@ namespace fuzzy
                                              AgendaItem(sentence_id, _p_length)).first.value();
 
       // The match will update the AgendaItem entry only if its length is the longest to date.
-      for (size_t j = agendaItem.maxmatch; j < match_length; j++)
+      if (match_length > agendaItem.maxmatch)
       {
-        if (!agendaItem.map_pattern[j])
+        for (size_t j = agendaItem.maxmatch; j < match_length; j++)
         {
-          agendaItem.map_pattern[j] = true;
-          agendaItem.coverage++;
+          if (!agendaItem.map_pattern[j])
+          {
+            agendaItem.map_pattern[j] = true;
+            agendaItem.coverage++;
+          }
         }
-      }
 
-      agendaItem.maxmatch = std::max<int>(agendaItem.maxmatch, match_length);
+        agendaItem.maxmatch = match_length;
+      }
     }
   }
 }

--- a/src/ngram_matches.cc
+++ b/src/ngram_matches.cc
@@ -55,8 +55,7 @@ namespace fuzzy
 
       // Get or create the AgendaItem corresponding to the sentence (of the suffix that matched)
       const auto sentence_id = _suffixArray.suffixid2sentenceid()[i].sentence_id;
-      auto& agendaItem = _psentences.emplace(sentence_id,
-                                             AgendaItem(sentence_id, _p_length)).first.value();
+      auto& agendaItem = _psentences.try_emplace(sentence_id, sentence_id, _p_length).first.value();
 
       // The match will update the AgendaItem entry only if its length is the longest to date.
       if (match_length > agendaItem.maxmatch)


### PR DESCRIPTION
* Rename the method to `register_suffix_range` for clarity
* Remove the `Range` structure that provides no additional value compared to just passing the values as argument
* Use a one-liner to replace `get_agendaitem` and `new_agendaitem`

The match output is unchanged.