### PR TITLE
Use a custom integer hash function for mapping sentence IDs

### DIFF
--- a/include/fuzzy/ngram_matches.hh
+++ b/include/fuzzy/ngram_matches.hh
@@ -47,8 +47,18 @@ namespace fuzzy
     size_t _longest_match;
   };
 
+  struct IntHash {
+    unsigned int operator()(unsigned int x) const {
+      // Credit: https://stackoverflow.com/a/12996028
+      x = ((x >> 16) ^ x) * 0x45d9f3b;
+      x = ((x >> 16) ^ x) * 0x45d9f3b;
+      x = (x >> 16) ^ x;
+      return x;
+    }
+  };
+
   // Sentence ID -> PatternMatch
-  using PatternMatches = tsl::hopscotch_map<unsigned, PatternMatch>;
+  using PatternMatches = tsl::hopscotch_map<unsigned, PatternMatch, IntHash>;
 
   class NGramMatches
   {


### PR DESCRIPTION
I found that the hash map (sentence ID -> PatternMatch) can have a lot of collisions in some cases, especially for the examples on which we have performance issue. Using this recommended custom hash function improves the performance.

On 10k examples:

|  | Match time (s) |
| --- | --- |
| before | 29.03 |
| after | 21.80 |