### PR TITLE
Cleanup SuffixArray getters

### DIFF
--- a/include/fuzzy/suffix_array.hh
+++ b/include/fuzzy/suffix_array.hh
@@ -15,7 +15,6 @@ namespace fuzzy
 {
   struct SuffixView
   {
-
     unsigned sentence_id;
     unsigned short subsentence_pos;
 
@@ -30,26 +29,20 @@ namespace fuzzy
     unsigned add_sentence(const std::vector<unsigned>& sentence);
     void sort(size_t vocab_size);
 
-    unsigned operator[](const SuffixView&) const;
-    unsigned operator[](size_t) const;
-    const std::vector<unsigned> &sentence_buffer() const;
-
     std::ostream& dump(std::ostream&) const;
 
-    size_t nsentences() const;
+    size_t num_sentences() const;
 
-    inline const unsigned* get_sentence(std::size_t sentence_id, std::size_t* length) const;
-    inline const unsigned* get_suffix(const SuffixView& p, std::size_t* length) const;
-    inline unsigned short sentence_length(std::size_t suffix_id) const;
+    const unsigned* get_sentence(size_t sentence_id, size_t* length = nullptr) const;
+    const unsigned* get_suffix(const SuffixView& p, size_t* length = nullptr) const;
+    const SuffixView& get_suffix_view(size_t suffix_id) const;
+    unsigned short get_sentence_length(size_t suffix_id) const;
 
     /** range of suffixe starting with ngram; return an open range so the number of elemem is just reS.second-res.first **/
     std::pair<size_t, size_t> equal_range(const unsigned* ngram,
                                           size_t length,
                                           size_t min = 0,
                                           size_t max = 0) const;
-
-    /** map suffix id -> sentence position */
-    const std::vector<SuffixView>   &suffixid2sentenceid() const;
 
   private:
     int comp(const SuffixView& a, const SuffixView& b) const;

--- a/include/fuzzy/suffix_array.hxx
+++ b/include/fuzzy/suffix_array.hxx
@@ -1,45 +1,39 @@
 namespace fuzzy
 {
-  inline unsigned SuffixArray::operator[](const SuffixView& pos)const
+  inline size_t
+  SuffixArray::num_sentences() const
   {
-    return (_sentence_buffer[_sentence_pos[pos.sentence_id]+pos.subsentence_pos]);
-  }
-
-  inline unsigned SuffixArray::operator[](size_t s_id)const
-  {
-    return _sentence_pos[s_id];
-  }
-
-  inline const std::vector<unsigned> &SuffixArray::sentence_buffer() const
-  {
-    return _sentence_buffer;
-  }
-
-  inline const std::vector<SuffixView> &SuffixArray::suffixid2sentenceid() const
-  {
-    return _suffixes;
+    return _sentence_pos.size();
   }
 
   inline const unsigned*
-  SuffixArray::get_sentence(std::size_t sentence_id, std::size_t* length) const
+  SuffixArray::get_sentence(size_t sentence_id, size_t* length) const
   {
     const auto offset = _sentence_pos[sentence_id];
     const auto* sentence = _sentence_buffer.data() + offset;
-    *length = *sentence;
+    if (length)
+      *length = *sentence;
     return sentence + 1;
   }
 
   inline const unsigned*
-  SuffixArray::get_suffix(const SuffixView& p, std::size_t* length) const
+  SuffixArray::get_suffix(const SuffixView& p, size_t* length) const
   {
     const auto* sentence = get_sentence(p.sentence_id, length);
     const auto prefix_length = p.subsentence_pos - 1;
-    *length -= prefix_length;
+    if (length)
+      *length -= prefix_length;
     return sentence + prefix_length;
   }
 
+  inline const SuffixView&
+  SuffixArray::get_suffix_view(size_t suffix_id) const
+  {
+    return _suffixes[suffix_id];
+  }
+
   inline unsigned short
-  SuffixArray::sentence_length(std::size_t suffix_id) const
+  SuffixArray::get_sentence_length(size_t suffix_id) const
   {
     return _sentence_length[suffix_id];
   }

--- a/src/fuzzy_match.cc
+++ b/src/fuzzy_match.cc
@@ -257,11 +257,11 @@ namespace fuzzy
 
     std::vector<float> idf_penalty;
     const std::vector<unsigned> &sfreq = SAI.get_VocabIndexer().getSFreq();
-    unsigned nsentences = SAI.get_SuffixArray().nsentences();
+    unsigned num_sentences = SAI.get_SuffixArray().num_sentences();
     idf_penalty.reserve(pidx.size());
     for(auto idx: pidx) {
       if (idx != fuzzy::VocabIndexer::VOCAB_UNK)
-        idf_penalty.push_back(std::log(nsentences*1.0/sfreq[idx]));
+        idf_penalty.push_back(std::log(num_sentences*1.0/sfreq[idx]));
       else
         /* unknown word - we cannot find a subsequence with it */
         idf_penalty.push_back(-1);
@@ -301,7 +301,7 @@ namespace fuzzy
 
       for(auto suffixIt=range_suffixid.first; suffixIt < range_suffixid.second &&
                                             candidates.size()<number_of_matches; suffixIt++) {
-        size_t s_id = SAI.get_SuffixArray().suffixid2sentenceid()[suffixIt].sentence_id;
+        size_t s_id = SAI.get_SuffixArray().get_suffix_view(suffixIt).sentence_id;
         if (candidates.find(s_id) == candidates.end() &&
             perfect.find(s_id) == perfect.end()) {
           size_t s_length = 0;
@@ -353,22 +353,22 @@ namespace fuzzy
   }
 
   float FuzzyMatch::compute_max_idf_penalty() const {
-    const unsigned nr_sentences = _suffixArrayIndex->get_SuffixArray().nsentences();
-    return std::log(nr_sentences);
+    const unsigned num_sentences = _suffixArrayIndex->get_SuffixArray().num_sentences();
+    return std::log(num_sentences);
   }
 
   std::vector<float> FuzzyMatch::compute_idf_penalty(const std::vector<unsigned>& pattern_wids) const {
     std::vector<float> idf_penalty;
     idf_penalty.reserve(pattern_wids.size());
 
-    const unsigned nr_sentences = _suffixArrayIndex->get_SuffixArray().nsentences();
+    const unsigned num_sentences = _suffixArrayIndex->get_SuffixArray().num_sentences();
 
     const std::vector<unsigned>& word_frequency_in_sentences = _suffixArrayIndex->get_VocabIndexer().getSFreq();
 
     for (const auto wid : pattern_wids) {
       // https://en.wikipedia.org/wiki/TF-IDF
       if (wid != fuzzy::VocabIndexer::VOCAB_UNK)
-        idf_penalty.push_back(std::log((float)nr_sentences/(float)word_frequency_in_sentences[wid]));
+        idf_penalty.push_back(std::log((float)num_sentences/(float)word_frequency_in_sentences[wid]));
       else
         idf_penalty.push_back(0);
     }

--- a/src/ngram_matches.cc
+++ b/src/ngram_matches.cc
@@ -45,12 +45,12 @@ namespace fuzzy
     for (auto i = begin; i < end; i++)
     {
       // The size difference between the suffix and the pattern is too large for the suffix to be accepted
-      const auto sizeDifference = std::abs((long int)_p_length - (long int)_suffixArray.sentence_length(i));
+      const auto sizeDifference = std::abs((long int)_p_length - (long int)_suffixArray.get_sentence_length(i));
       if (sizeDifference > max_differences_with_pattern)
         continue;
 
       // Get or create the PatternMatch corresponding to the sentence (of the suffix that matched)
-      const auto sentence_id = _suffixArray.suffixid2sentenceid()[i].sentence_id;
+      const auto sentence_id = _suffixArray.get_suffix_view(i).sentence_id;
       auto& pattern_match = _pattern_matches.try_emplace(sentence_id, _p_length).first.value();
       pattern_match.set_match(match_offset, match_length);
     }

--- a/src/suffix_array.cc
+++ b/src/suffix_array.cc
@@ -66,8 +66,7 @@ namespace fuzzy
     // sort suffixes according to their first word id
     for (const auto& suffix : _suffixes)
     {
-      const auto* suffix_wids = get_suffix(suffix);
-      const auto wid = suffix_wids[0];
+      const auto wid = get_suffix(suffix)[0];
       assert((size_t)wid < vocab_size);
 
       prefixes_by_word_id[wid].push_back(suffix);

--- a/src/suffix_array.cc
+++ b/src/suffix_array.cc
@@ -54,12 +54,6 @@ namespace fuzzy
   }
 #endif
 
-  size_t
-  SuffixArray::nsentences() const
-  {
-    return _sentence_pos.size();
-  }
-
   void
   SuffixArray::sort(size_t vocab_size)
   {
@@ -70,12 +64,13 @@ namespace fuzzy
     std::vector<std::vector<SuffixView> > prefixes_by_word_id(vocab_size);
 
     // sort suffixes according to their first word id
-    for (size_t i = 0; i < _suffixes.size(); i++)
+    for (const auto& suffix : _suffixes)
     {
-      const auto wid = (*this)[_suffixes[i]];
+      const auto* suffix_wids = get_suffix(suffix);
+      const auto wid = suffix_wids[0];
       assert((size_t)wid < vocab_size);
 
-      prefixes_by_word_id[wid].push_back(_suffixes[i]);
+      prefixes_by_word_id[wid].push_back(suffix);
     }
 
     _suffixes.clear();

--- a/src/suffix_array_index.cc
+++ b/src/suffix_array_index.cc
@@ -35,12 +35,12 @@ namespace fuzzy
   SuffixArrayIndex::sentence(size_t sindex) const
   {
     std::string sent =">";
-    size_t idx = _suffixArray[sindex];
+    size_t slength = 0;
+    const auto* sentence = _suffixArray.get_sentence(sindex, &slength);
 
-    for (size_t j = 1; _suffixArray.sentence_buffer()[idx + j]; j++)
+    for (size_t j = 0; j < slength; j++)
     {
-      int ind = _suffixArray.sentence_buffer()[idx + j];
-      std::string form = _vocabIndexer.getWord(ind);
+      std::string form = _vocabIndexer.getWord(sentence[j]);
       if (!sent.empty())
         sent += " ";
       sent += form;


### PR DESCRIPTION
* `operator[]`: it's not immediately clear what is being indexed. We should use `get_sentence` or `get_suffix` instead.
* `sentence_buffer`: this buffer should remain private
* `suffixid2sentenceid`: the name is incorrect since it maps to `SuffixView` objects not sentence IDs, and we don't need to return the full vector.
* `nsentences`: this small getter should be implemented in a header file.