### PR TITLE
Only resolve the longest match when registering suffixes

### DIFF
--- a/include/fuzzy/pattern_coverage.hh
+++ b/include/fuzzy/pattern_coverage.hh
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <map>
+#include <vector>
+
+namespace fuzzy
+{
+
+  class PatternCoverage
+  {
+  public:
+    PatternCoverage(const std::vector<unsigned>& pattern);
+
+    // Counts the number of words in the pattern that are also in the sentence.
+    size_t count_covered_words(const unsigned* sentence, size_t sentence_length) const;
+
+  private:
+    std::map<unsigned, std::vector<size_t>> _words_positions;
+    size_t _pattern_length;
+  };
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(FUZZY_SOURCES
   sentence.cc
   fuzzy_matcher_binarization.cc
   edit_distance.cc
+  pattern_coverage.cc
 )
 
 if (COMMAND create_library)

--- a/src/ngram_matches.cc
+++ b/src/ngram_matches.cc
@@ -25,17 +25,14 @@ namespace fuzzy
   {
   }
 
-  PatternMatches&
-  NGramMatches::get_pattern_matches()
+  const LongestMatches&
+  NGramMatches::get_longest_matches() const
   {
-    return _pattern_matches;
+    return _longest_matches;
   }
 
   void
-  NGramMatches::register_suffix_range_match(size_t begin,
-                                            size_t end,
-                                            size_t match_offset,
-                                            size_t match_length)
+  NGramMatches::register_suffix_range_match(size_t begin, size_t end, unsigned match_length)
   {
     // lazy injection feature - if match_length smaller than min_seq_len, we will not process the suffixes for the moment
     if (match_length < min_exact_match || match_length < _min_seq_len)
@@ -51,8 +48,8 @@ namespace fuzzy
 
       // Get or create the PatternMatch corresponding to the sentence (of the suffix that matched)
       const auto sentence_id = _suffixArray.get_suffix_view(i).sentence_id;
-      auto& pattern_match = _pattern_matches.try_emplace(sentence_id, _p_length).first.value();
-      pattern_match.set_match(match_offset, match_length);
+      auto& longest_match = _longest_matches.try_emplace(sentence_id, match_length).first.value();
+      longest_match = std::max(longest_match, match_length);
     }
   }
 }

--- a/src/pattern_coverage.cc
+++ b/src/pattern_coverage.cc
@@ -1,0 +1,37 @@
+#include "fuzzy/pattern_coverage.hh"
+
+namespace fuzzy
+{
+
+  PatternCoverage::PatternCoverage(const std::vector<unsigned>& pattern)
+    : _pattern_length(pattern.size())
+  {
+    for (size_t i = 0; i < pattern.size(); ++i)
+      _words_positions[pattern[i]].push_back(i);
+  }
+
+  size_t PatternCoverage::count_covered_words(const unsigned* sentence, size_t sentence_length) const
+  {
+    std::vector<bool> covered_words(_pattern_length, false);
+    size_t num_covered_words = 0;
+
+    for (size_t i = 0; i < sentence_length; ++i)
+    {
+      const auto it = _words_positions.find(sentence[i]);
+      if (it == _words_positions.end())  // Sentence word is not in the pattern.
+        continue;
+
+      for (const auto position : it->second)
+      {
+        if (!covered_words[position])
+        {
+          covered_words[position] = true;
+          num_covered_words++;
+        }
+      }
+    }
+
+    return num_covered_words;
+  }
+
+}


### PR DESCRIPTION
When registering a match over suffixes, the code was tracking the longest match for each sentence and also marking the words in the pattern that appear in the sentence. However, there is no need to mark the words at this stage, because in the second part of the algorithm (last `for` loop of `match` method) we iterate again over the sentence to find the words that are also in the pattern.