### PR TITLE
Update the cost upper bound to return early from edit_distance

### DIFF
--- a/include/fuzzy/edit_distance.hh
+++ b/include/fuzzy/edit_distance.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include <fuzzy/sentence.hh>
 #include <fuzzy/costs.hh>
 
@@ -11,7 +13,8 @@ namespace fuzzy
                        const unsigned* thep, const Tokens &realptok, int plen,
                        const std::vector<const char*>& st, const std::vector<int>& sn,
                        const std::vector<float> &idf_penalty, float idf_weight,
-                       const Costs&, float max_fuzziness);
+                       const Costs&,
+                       float max_fuzziness = std::numeric_limits<float>::max());
 }
 
 #include <fuzzy/edit_distance.hxx>

--- a/src/edit_distance.cc
+++ b/src/edit_distance.cc
@@ -1,7 +1,5 @@
 #include <fuzzy/edit_distance.hh>
 
-#include <limits>
-
 namespace fuzzy
 {
   float
@@ -35,11 +33,9 @@ namespace fuzzy
       cost_tag[0][j] = costs.penalty * _edit_distance_char(st1[0], sn1[0], st2[j], sn2[j]);
     }
 
-    constexpr auto max_float = std::numeric_limits<float>::max();
-
     for (int i = 1; i < n1 + 1; i++)
     {
-      float min = max_float;
+      float min = std::numeric_limits<float>::max();
       for (int j = 1; j < n2 + 1; j++)
       {
         int diff = 0;
@@ -70,7 +66,7 @@ namespace fuzzy
         arr[i][j] = distance;
         min = std::min(min, distance);
       }
-      if (min != max_float && min > max_fuzzyness)
+      if (min > max_fuzzyness)
         return min;
     }
 #ifdef DEBUG

--- a/src/fuzzy_match.cc
+++ b/src/fuzzy_match.cc
@@ -522,6 +522,9 @@ namespace fuzzy
 
     real.get_itoks(st, sn);
 
+    // We track the lowest costs in order the call the edit distance with an upper bound
+    // and possibly return earlier. The default upper bound is "FLT_MAX (i.e. no restriction).
+    // The restriction will only start when we pop this value from the heap.
     std::priority_queue<float> lowest_costs;
     lowest_costs.push(std::numeric_limits<float>::max());
 

--- a/src/fuzzy_match.cc
+++ b/src/fuzzy_match.cc
@@ -523,7 +523,7 @@ namespace fuzzy
     real.get_itoks(st, sn);
 
     // We track the lowest costs in order the call the edit distance with an upper bound
-    // and possibly return earlier. The default upper bound is "FLT_MAX (i.e. no restriction).
+    // and possibly return earlier. The default upper bound is FLT_MAX (i.e. no restriction).
     // The restriction will only start when we pop this value from the heap.
     std::priority_queue<float> lowest_costs;
     lowest_costs.push(std::numeric_limits<float>::max());

--- a/src/fuzzy_match.cc
+++ b/src/fuzzy_match.cc
@@ -559,8 +559,7 @@ namespace fuzzy
         float score = int(10000-cost*100)/10000.0;
 
         lowest_costs.push(cost);
-        if ((number_of_matches > 0 && lowest_costs.size() > number_of_matches)
-            || (number_of_matches == 0 && score < fuzzy))
+        if (score < fuzzy || (number_of_matches > 0 && lowest_costs.size() > number_of_matches))
           lowest_costs.pop();
 
         if (score >= fuzzy) {


### PR DESCRIPTION
The cost upper bound was hardcoded to `100-fuzzy` which seems very arbitrary.

This change handles 2 cases:
* when `number_of_matches > 0`, we keep the `number_of_matches` lowest costs and use the highest cost from them as the upper bound 
* when `number_of_matches = 0` (return all sentences above the fuzzy threshold), the upper bound is updated to be the smallest cost that produces a score below the fuzzy threshold.

I verified that outputs are the same on 10k samples.