### PR TITLE
Iterate on sentences from longest to shortest match

### DIFF
--- a/include/fuzzy/ngram_matches.hh
+++ b/include/fuzzy/ngram_matches.hh
@@ -30,7 +30,7 @@ namespace fuzzy
     // Registers a match for this range of suffixes.
     void register_suffix_range_match(size_t begin, size_t end, unsigned match_length);
 
-    const LongestMatches& get_longest_matches() const;
+    std::vector<std::pair<unsigned, unsigned>> get_longest_matches() const;
 
     unsigned max_differences_with_pattern;
     unsigned min_exact_match; // Any suffix without an subsequence of at least this with the pattern won't be accepted later

--- a/src/ngram_matches.cc
+++ b/src/ngram_matches.cc
@@ -25,10 +25,16 @@ namespace fuzzy
   {
   }
 
-  const LongestMatches&
+  std::vector<std::pair<unsigned, unsigned>>
   NGramMatches::get_longest_matches() const
   {
-    return _longest_matches;
+    std::vector<std::pair<unsigned, unsigned>> sorted_matches(_longest_matches.begin(),
+                                                              _longest_matches.end());
+    std::sort(sorted_matches.begin(), sorted_matches.end(),
+              [](const std::pair<unsigned, unsigned>& a, const std::pair<unsigned, unsigned>& b) {
+                return a.second > b.second || (a.second == b.second && a.first < b.first);
+              });
+    return sorted_matches;
   }
 
   void


### PR DESCRIPTION
A long consecutive match is correlated with a low edit distance, so by iterating on long matches first we can quickly set a strict upper bound on the edit distance. This change reduces the match time even though it copies and sorts the list of candidate sentences.

A future improvement could be to filter this list of sentences (e.g. only keep long matches), but it's not immediately clear what filtering rules to apply since various penalties could still be applied to a long match.