### PR TITLE
Add include<stdexcept>, necessary to use std::invalid_argument, for s…

### DIFF
--- a/include/fuzzy/suffix_array.hxx
+++ b/include/fuzzy/suffix_array.hxx
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 namespace fuzzy
 {
   inline size_t


### PR DESCRIPTION
…ome compilers.