### PR TITLE
removed irrelevant filter

### DIFF
--- a/src/ngram_matches.cc
+++ b/src/ngram_matches.cc
@@ -4,21 +4,12 @@
 
 namespace fuzzy
 {
-  unsigned compute_min_exact_match(float fuzzy, unsigned p_length)
-  {
-    const auto differences = (unsigned)std::ceil(p_length * (1.f - fuzzy));
-    // we split (p_length - differences) in  (differences + 1) parts
-    // the minimum value of the largest part size is obtained by dividing and taking ceil
-    return std::ceil((p_length - differences) / (differences + 1.));
-  }
-
   NGramMatches::NGramMatches(float fuzzy,
                              unsigned p_length,
                              unsigned min_seq_len,
                              const SuffixArray& suffixArray)
     /* add a small epsilon to avoid rounding errors counting for an error */
     : max_differences_with_pattern((unsigned)std::floor(p_length * (1.f - fuzzy) + 0.00005)),
-      min_exact_match(compute_min_exact_match(fuzzy, p_length)),
       _p_length(p_length),
       _min_seq_len(min_seq_len),
       _suffixArray(suffixArray)
@@ -41,7 +32,7 @@ namespace fuzzy
   NGramMatches::register_suffix_range_match(size_t begin, size_t end, unsigned match_length)
   {
     // lazy injection feature - if match_length smaller than min_seq_len, we will not process the suffixes for the moment
-    if (match_length < min_exact_match || match_length < _min_seq_len)
+    if (match_length < _min_seq_len)
       return;
 
     // For each suffix that matches at least match_length


### PR DESCRIPTION
(True one)
Removed filter judged irrelevant in NGramMatches:
- Does not change the test results
- On ECB with high threshold value, less than 1% difference, and extra retrieved fuzzy with scores above threshold (better)
